### PR TITLE
Fix LDI, LDIR, LDD, LDDR

### DIFF
--- a/src/z80/instructions.py
+++ b/src/z80/instructions.py
@@ -1956,7 +1956,7 @@ class InstructionSet():
                  2, "IN {0}, (C)", 12)
     def in_r_c(instruction, registers, get_reads, data, r):
         if get_reads:
-            address = registers[r] | (registers.B << 8) #n | (registers.A << 8)
+            address = registers.C | (registers.B << 8) #n | (registers.A << 8)
             return [address+0x10000]
         else:
             registers.condition.S = data[0] & 0x80
@@ -1966,7 +1966,7 @@ class InstructionSet():
             registers.condition.N = 0
             if r == "F":
                 return []
-            #registers[r] = data[0]
+            registers[r] = data[0]
             return []
         
     @instruction([([0xed, 0xa2], ( )) ] ,

--- a/src/z80/instructions.py
+++ b/src/z80/instructions.py
@@ -1956,7 +1956,7 @@ class InstructionSet():
                  2, "IN {0}, (C)", 12)
     def in_r_c(instruction, registers, get_reads, data, r):
         if get_reads:
-            address = registers.C | (registers.B << 8) #n | (registers.A << 8)
+            address = registers[r] | (registers.B << 8) #n | (registers.A << 8)
             return [address+0x10000]
         else:
             registers.condition.S = data[0] & 0x80
@@ -1966,7 +1966,7 @@ class InstructionSet():
             registers.condition.N = 0
             if r == "F":
                 return []
-            registers[r] = data[0]
+            #registers[r] = data[0]
             return []
         
     @instruction([([0xed, 0xa2], ( )) ] ,

--- a/src/z80/instructions.py
+++ b/src/z80/instructions.py
@@ -538,7 +538,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
     @instruction([(0xEDB0, ())], 0, "LDIR", 21)
     def ldir(instruction, registers, get_reads, data):
@@ -572,7 +572,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
 
     @instruction([(0xEDA8, ())], 0, "LDD", 16)
@@ -604,7 +604,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
     @instruction([(0xEDB8, ())], 0, "LDDR", 16)
     def lddr(instruction, registers, get_reads, data):
@@ -638,7 +638,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
 
     @instruction([(0xEDA1, ())], 0, "CPI", 16)


### PR DESCRIPTION
LDI. LDIR, LDD and LDDR were storing the data at the wrong address. The right address was already stored in variable de_ but for some reason it was not being used.