### PR TITLE
Fix LDI, LDIR, LDD, LDDR

### DIFF
--- a/src/z80/instructions.py
+++ b/src/z80/instructions.py
@@ -538,7 +538,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
     @instruction([(0xEDB0, ())], 0, "LDIR", 21)
     def ldir(instruction, registers, get_reads, data):
@@ -572,7 +572,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
 
     @instruction([(0xEDA8, ())], 0, "LDD", 16)
@@ -604,7 +604,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
     @instruction([(0xEDB8, ())], 0, "LDDR", 16)
     def lddr(instruction, registers, get_reads, data):
@@ -638,7 +638,7 @@ class InstructionSet():
             registers.condition.N = 0
             registers.condition.F3 = (registers.A + data[0]) & 0x08
             registers.condition.F5 = (registers.A + data[0]) & 0x02
-            return [(de, data[0])]
+            return [(de_, data[0])]
 
 
     @instruction([(0xEDA1, ())], 0, "CPI", 16)


### PR DESCRIPTION
LDI, LDIR, LDD and LDDR instrucions were storing data at the wrong address. The right one was already stored at de_ but it was not being used for some reason.