### PR TITLE
Fix flag C for ADD,ADC,SUB,SBC

### DIFF
--- a/src/z80/instructions.py
+++ b/src/z80/instructions.py
@@ -1350,7 +1350,7 @@ class InstructionSet():
             registers.condition.F3 = dummy_reg.condition.F3
             registers.condition.F5 = dummy_reg.condition.F5
             registers.condition.N = 0
-            registers.condition.C = val > 0xFFFF
+            registers.condition.C = ((val & 0x10000) != 0)
             registers.HL = val & 0xFFFF
             return []
 
@@ -1389,7 +1389,7 @@ class InstructionSet():
             else:
                 registers.condition.PV = 0
         
-            registers.condition.C = res > 0xFFFF or res < 0
+            registers.condition.C = ((res & 0x10000) != 0)
             registers.HL = res &  0xFFFF
 
             return []
@@ -1407,7 +1407,7 @@ class InstructionSet():
             else:
                 registers.condition.H = 0
             registers.condition.N = 0
-            registers.condition.C = val > 0xFFFF
+            registers.condition.C = ((val & 0x10000) != 0)
             set_f5_f3(registers, (registers[i] >>8)+(registers[r]>>8))
             registers[i] = val & 0xFFFF
             return []

--- a/src/z80/util.py
+++ b/src/z80/util.py
@@ -68,7 +68,7 @@ def subtract8(a, b, registers, S=True, N=True, Z=True,
         else:
             registers.condition.PV = 0
     if C:
-        registers.condition.C = res > 0xFF or res < 0
+        registers.condition.C = ((res & 0x100) != 0)
     return res &  0xFF
     
 def subtract8_check_overflow(a, b, registers):
@@ -95,7 +95,7 @@ def add8(a, b, registers, S=True, Z=True, H=True,
     if N:
         registers.condition.N = 0
     if C:
-        registers.condition.C = res > 0xFF or res < 0
+        registers.condition.C = ((res & 0x100) != 0)
     if F3:
         registers.condition.F3 = res & 0x08
     if F5:
@@ -117,7 +117,7 @@ def add16(a, b, registers):
     else:
         registers.condition.PV = 0
     registers.condition.N = 0
-    registers.condition.C = res >> 0xFFFF or res < 0
+    registers.condition.C = ((res & 0x10000) != 0)
     
     registers.condition.F3 = res & 0x0800
     registers.condition.F5 = res & 0x2000
@@ -142,7 +142,7 @@ def subtract16(a, b, registers):
     else:
         registers.condition.PV = 0
 
-    registers.condition.C = res > 0xFFFF or res < 0
+    registers.condition.C = ((res & 0x10000) != 0)
     return res &  0xFFFF
 
 def inc16(val):


### PR DESCRIPTION
Flag C was not always correctly set for arithmetic instructions. It was breaking ZX Spectrum BASIC: "BEEP 1,1" returned an error.
This implementation is based on openMSX code.